### PR TITLE
Removed mod apps

### DIFF
--- a/fbh.yaml
+++ b/fbh.yaml
@@ -267,12 +267,7 @@ title: "You have probably broken one of the rules of the channel. You may find t
 
 ---
 id: server-roles-staff
-title: "Ahoy Sailors,\n
-We at FredBoat are happy to announce the first round of Moderator Applications! Applications will remain open until July 31st 2020. We are excited to see what the community is able to bring forward and thank all those who show interest in becoming part of our staff.\n
-\n
-Please apply at https://forms.gle/7YvvNcj3R2tfs4Ka7\n
-\n
--FredBoat Team"
+title: "Thank you for your interest, but the staff at FredBoat Hangout are not accepting applications for their team."
 
 ---
 id: server-ads


### PR DESCRIPTION
So I went to this section on Baymax today and saw that applications were closed, so I thought I'd revert the mod apps back to what they were before as they are now over (the form is closed and the deadline is well passed), just so everything is kept up to date :slightly_smiling_face: 